### PR TITLE
Update createServer fn types

### DIFF
--- a/typescript/src/server/stateful.ts
+++ b/typescript/src/server/stateful.ts
@@ -4,7 +4,7 @@ import express from "express"
 import { randomUUID } from "node:crypto"
 import { parseExpressRequestConfig } from "../config.js"
 
-import type { Server } from "@modelcontextprotocol/sdk/server/index.js"
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 
 /**
  * Arguments when we create a new instance of your server
@@ -16,7 +16,7 @@ export interface CreateServerArg<T = Record<string, unknown>> {
 
 export type CreateServerFn<T = Record<string, unknown>> = (
 	arg: CreateServerArg<T>,
-) => Server
+) => McpServer
 
 /**
  * Creates a stateful server for handling MCP requests.
@@ -26,7 +26,7 @@ export type CreateServerFn<T = Record<string, unknown>> = (
  */
 export function createStatefulServer<T = Record<string, unknown>>(
 	createMcpServer: CreateServerFn<T>,
-) {
+): { app: express.Express } {
 	const app = express()
 	app.use(express.json())
 

--- a/typescript/src/server/stateless.ts
+++ b/typescript/src/server/stateless.ts
@@ -3,7 +3,7 @@ import type { Request, Response } from "express"
 import express from "express"
 import { parseExpressRequestConfig } from "../config.js"
 
-import type { Server } from "@modelcontextprotocol/sdk/server/index.js"
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 
 /**
  * Arguments when we create a new instance of your server
@@ -14,7 +14,7 @@ export interface CreateServerArg<T = Record<string, unknown>> {
 
 export type CreateServerFn<T = Record<string, unknown>> = (
 	arg: CreateServerArg<T>,
-) => Server
+) => McpServer
 
 /**
  * Creates a stateless server for handling MCP requests
@@ -24,7 +24,7 @@ export type CreateServerFn<T = Record<string, unknown>> = (
  */
 export function createStatelessServer<T = Record<string, unknown>>(
 	createMcpServer: CreateServerFn<T>,
-) {
+): { app: express.Express } {
 	const app = express()
 	app.use(express.json())
 


### PR DESCRIPTION
Update types for `createStatefulServer` and `createStatelessServer` to work with example from [README](https://github.com/smithery-ai/sdk/tree/main/typescript#spawning-a-server)